### PR TITLE
FIX: Don't assume SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"type": "silverstripe-theme",
 	"require": {
 		"composer/installers": "*",
-		"silverstripe/framework": ">=3.0"
+		"silverstripe/framework": "^3.0"
 	},
 	"version": "3.0.0-wip",
 	"extra": {


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS4.

This will also ensure that addons.silverstripe.org correctly reports which modules
work with SS4.